### PR TITLE
Switches to postgresql

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,8 @@ gem 'sdoc', '~> 0.4.0', group: :doc
 # Discussion: https://github.com/18F/college-choice/issues/597#issuecomment-139034834
 gem "puma", "~> 2.16.0"
 
+gem 'pg', platforms: :ruby
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: :ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -153,6 +153,7 @@ GEM
       shellany (~> 0.0)
     parser (2.3.1.4)
       ast (~> 2.2)
+    pg (0.18.4)
     poltergeist (1.11.0)
       capybara (~> 2.1)
       cliver (~> 0.3.1)
@@ -300,6 +301,7 @@ DEPENDENCIES
   jbuilder (~> 2.0)
   jquery-rails
   jshint
+  pg
   puma (~> 2.16.0)
   rails (= 4.2.7.1)
   rainbow

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,25 +1,19 @@
-# SQLite version 3.x
-#   gem install sqlite3
-#
-#   Ensure the SQLite 3 gem is defined in your Gemfile
-#   gem 'sqlite3'
-#
 default: &default
-  adapter: sqlite3
-  pool: 5
+  adapter: postgresql
+  encoding: unicode
+  pool: <%= ENV["DB_CONN_POOL_MAX_SIZE"] || 5 %>
   timeout: 5000
 
 development:
   <<: *default
-  database: db/development.sqlite3
+  username: <%= `whoami` %>
+  database: caseflow_feedback_development
 
-# Warning: The database defined as "test" will be erased and
-# re-generated from your development database when you run "rake".
-# Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: db/test.sqlite3
+  username: <%= `whoami` %>
+  database: caseflow_feedback_test
 
 production:
   <<: *default
-  database: db/production.sqlite3
+  url: <%= ENV["POSTGRES_URL"] %>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -13,6 +13,9 @@
 
 ActiveRecord::Schema.define(version: 20161116154114) do
 
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
   create_table "feedback", force: :cascade do |t|
     t.string   "application"
     t.string   "username"


### PR DESCRIPTION
Switching to postgres from sqlite.

Reasons: we expect to use this app across all of caseflow, so simultaneous writes might get too much for sqlite fairly quickly. Best to upgrade now since it takes basically no time at all :)

You'll need to re-run `rake db:create db:migrate` `rake db:create db:migrate RAILS_ENV=test` after this is merged.