### PR TITLE
Changed name of field application to subject and fixed relevant views…

### DIFF
--- a/app/controllers/feedback_controller.rb
+++ b/app/controllers/feedback_controller.rb
@@ -9,7 +9,7 @@ class FeedbackController < ApplicationController
 
   def new
     @feedback = Feedback.new
-    session[:subject] = params[:subject] || "Dispatch"
+    session[:subject] = params[:subject] || "Caseflow"
     session[:redirect] = params[:redirect] || "https://www.va.gov"
   end
 

--- a/app/controllers/feedback_controller.rb
+++ b/app/controllers/feedback_controller.rb
@@ -9,6 +9,7 @@ class FeedbackController < ApplicationController
 
   def new
     @feedback = Feedback.new
+    session[:subject] = params[:subject] || "Dispatch"
     session[:redirect] = params[:redirect] || "https://www.va.gov"
   end
 
@@ -32,6 +33,6 @@ class FeedbackController < ApplicationController
   def feedback_params
     params.require(:feedback)
           .permit(:feedback, :contact_email)
-          .merge(application: app_display_name, username: current_user.display_name)
+          .merge(subject: session[:subject], username: current_user.display_name)
   end
 end

--- a/app/helpers/feedback_helper.rb
+++ b/app/helpers/feedback_helper.rb
@@ -1,11 +1,4 @@
 module FeedbackHelper
-  # def app_display_name
-  #   # Extracts domain name from entire url
-  #   app_domain = Addressable::URI.parse(session[:redirect]).host
-  #   # Finds application name based on domain
-  #   Rails.configuration.url_to_subject[app_domain]
-  # end
-
   def app_display_url
     session[:redirect]
   end

--- a/app/helpers/feedback_helper.rb
+++ b/app/helpers/feedback_helper.rb
@@ -1,10 +1,10 @@
 module FeedbackHelper
-  def app_display_name
-    # Extracts domain name from entire url
-    app_domain = Addressable::URI.parse(session[:redirect]).host
-    # Finds application name based on domain
-    Rails.configuration.app_names[app_domain]
-  end
+  # def app_display_name
+  #   # Extracts domain name from entire url
+  #   app_domain = Addressable::URI.parse(session[:redirect]).host
+  #   # Finds application name based on domain
+  #   Rails.configuration.url_to_subject[app_domain]
+  # end
 
   def app_display_url
     session[:redirect]

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -1,5 +1,5 @@
 class Feedback < ActiveRecord::Base
-  validates :application, :username, :feedback, presence: true
+  validates :subject, :username, :feedback, presence: true
   validates :contact_email, length: { maximum: 255 }, format: { with: /\A\S*@\S*\z/ }, allow_blank: true
   enum status: {
     open: 0,

--- a/app/views/feedback/admin.html.erb
+++ b/app/views/feedback/admin.html.erb
@@ -19,7 +19,7 @@
               <td class="align-top"><%= feedback.contact_email %></td>
             <% end %>
             <td class="align-top"><%= feedback.created_at.strftime("%m/%d/%Y") %></td>
-            <td class="align-top"><%= feedback.application %></td>
+            <td class="align-top"><%= feedback.subject %></td>
             <td class="align-top"><%= feedback.feedback %></td>
             <td class="align-top">
               <% unless feedback.admin_note.nil? %>

--- a/app/views/feedback/new.html.erb
+++ b/app/views/feedback/new.html.erb
@@ -14,7 +14,7 @@
       </div>
     <% end %>
     <div>
-      <h2>Tell us about your experience with <%= app_display_name %>.</h2>
+      <h2>Tell us about your experience with <%= session[:subject] %>.</h2>
       <p> What's working well? What's not working? Your comments will help us improve Caseflow for everyone.</p>
     </div>
     <div>

--- a/app/views/feedback/success.html.erb
+++ b/app/views/feedback/success.html.erb
@@ -5,7 +5,7 @@
   </div>
   <div class="cf-app-segment">
     <a href='<%= app_display_url %>'>
-      <button class="cf-submit cf-push-right" >Back to <%= app_display_name %></button>
+      <button class="cf-submit cf-push-right" >Back to <%= session[:subject] %></button>
    </a>
   </div>
 </div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -29,8 +29,5 @@ module CaseflowFeedback
 
     # Gzip files when possible
     config.middleware.use Rack::Deflater
-
-    #Caseflow application official names based on domain name
-    config.app_names = {"www.va.gov" => "Caseflow Certification", "caseflow.ds.va.gov" => "Caseflow Certification", "efolder.cf.ds.va.gov"=> "eFolder Express"}
   end
 end

--- a/db/migrate/20161201194922_change_application_column_name.rb
+++ b/db/migrate/20161201194922_change_application_column_name.rb
@@ -1,0 +1,5 @@
+class ChangeApplicationColumnName < ActiveRecord::Migration
+  def change
+    rename_column :feedback, :application, :subject
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,13 +11,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161128201404) do
+ActiveRecord::Schema.define(version: 20161201194922) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "feedback", force: :cascade do |t|
-    t.string   "application"
+    t.string   "subject"
     t.string   "username"
     t.text     "feedback"
     t.datetime "created_at",                null: false

--- a/spec/feature/admin_page_spec.rb
+++ b/spec/feature/admin_page_spec.rb
@@ -23,7 +23,7 @@ RSpec.feature "Admin Page " do
 
   scenario "Post feedback and make sure it shows on Feedback View" do
     visit "/feedback/new"
-    expect(page).to have_content("Tell us about your experience with Caseflow Certification")
+    expect(page).to have_content("Tell us about your experience with Dispatch")
     expect(page).to have_css("#feedback_feedback")
     page.should have_link("Cancel")
     fill_in "feedback_feedback", with: "Feedback Posting Test"
@@ -31,7 +31,7 @@ RSpec.feature "Admin Page " do
     click_on "Send Feedback"
     expect(page).to have_content("Thanks for your feedback!")
     click_on "Send in more feedback"
-    expect(page).to have_content("Tell us about your experience with Caseflow Certification")
+    expect(page).to have_content("Tell us about your experience with Dispatch")
     fill_in "feedback_feedback", with: "Feedback Posting Test 2"
     # leave contact email field empty
     click_on "Send Feedback"
@@ -40,10 +40,10 @@ RSpec.feature "Admin Page " do
     visit "/admin"
     expect(page).to have_content("fk@va.gov")
     expect(page).to have_content(Date.current.strftime("%m/%d/%Y"))
-    expect(page).to have_content("Caseflow Certification")
+    expect(page).to have_content("Dispatch")
     expect(page).to have_content("Feedback Posting Test")
     expect(page).to have_content("ANNE MERICA (283)")
-    expect(page).to have_content("Caseflow Certification")
+    expect(page).to have_content("Dispatch")
     expect(page).to have_content("Feedback Posting Test 2")
   end
 end

--- a/spec/feature/admin_page_spec.rb
+++ b/spec/feature/admin_page_spec.rb
@@ -23,7 +23,7 @@ RSpec.feature "Admin Page " do
 
   scenario "Post feedback and make sure it shows on Feedback View" do
     visit "/feedback/new"
-    expect(page).to have_content("Tell us about your experience with Dispatch")
+    expect(page).to have_content("Tell us about your experience with Caseflow")
     expect(page).to have_css("#feedback_feedback")
     page.should have_link("Cancel")
     fill_in "feedback_feedback", with: "Feedback Posting Test"
@@ -31,7 +31,7 @@ RSpec.feature "Admin Page " do
     click_on "Send Feedback"
     expect(page).to have_content("Thanks for your feedback!")
     click_on "Send in more feedback"
-    expect(page).to have_content("Tell us about your experience with Dispatch")
+    expect(page).to have_content("Tell us about your experience with Caseflow")
     fill_in "feedback_feedback", with: "Feedback Posting Test 2"
     # leave contact email field empty
     click_on "Send Feedback"
@@ -40,10 +40,10 @@ RSpec.feature "Admin Page " do
     visit "/admin"
     expect(page).to have_content("fk@va.gov")
     expect(page).to have_content(Date.current.strftime("%m/%d/%Y"))
-    expect(page).to have_content("Dispatch")
+    expect(page).to have_content("Caseflow")
     expect(page).to have_content("Feedback Posting Test")
     expect(page).to have_content("ANNE MERICA (283)")
-    expect(page).to have_content("Dispatch")
+    expect(page).to have_content("Caseflow")
     expect(page).to have_content("Feedback Posting Test 2")
   end
 end

--- a/spec/feature/enter_feedback_spec.rb
+++ b/spec/feature/enter_feedback_spec.rb
@@ -8,19 +8,19 @@ RSpec.feature "Enter feedback" do
 
   scenario "Load Feedback page" do
     visit "/feedback/new"
-    expect(page).to have_content("Tell us about your experience with Caseflow Certification")
+    expect(page).to have_content("Tell us about your experience with Dispatch")
     expect(page).to have_css("#feedback_feedback")
     page.should have_link("Cancel")
     fill_in "feedback_feedback", with: "Feedback"
     fill_in "feedback_contact_email", with: "fk@va.gov"
     click_on "Send Feedback"
     expect(page).to have_content("Thanks for your feedback!")
-    expect(page).to have_content("Back to Caseflow Certification")
+    expect(page).to have_content("Back to Dispatch")
     click_on "Send in more feedback"
-    expect(page).to have_content("Tell us about your experience with Caseflow Certification")
+    expect(page).to have_content("Tell us about your experience with Dispatch")
     fill_in "feedback_feedback", with: "Feedback"
     click_on "Send Feedback"
     expect(page).to have_content("Thanks for your feedback!")
-    page.should have_link("Back to Caseflow Certification", href: "https://www.va.gov")
+    page.should have_link("Back to Dispatch", href: "https://www.va.gov")
   end
 end

--- a/spec/feature/enter_feedback_spec.rb
+++ b/spec/feature/enter_feedback_spec.rb
@@ -8,19 +8,19 @@ RSpec.feature "Enter feedback" do
 
   scenario "Load Feedback page" do
     visit "/feedback/new"
-    expect(page).to have_content("Tell us about your experience with Dispatch")
+    expect(page).to have_content("Tell us about your experience with Caseflow")
     expect(page).to have_css("#feedback_feedback")
     page.should have_link("Cancel")
     fill_in "feedback_feedback", with: "Feedback"
     fill_in "feedback_contact_email", with: "fk@va.gov"
     click_on "Send Feedback"
     expect(page).to have_content("Thanks for your feedback!")
-    expect(page).to have_content("Back to Dispatch")
+    expect(page).to have_content("Back to Caseflow")
     click_on "Send in more feedback"
-    expect(page).to have_content("Tell us about your experience with Dispatch")
+    expect(page).to have_content("Tell us about your experience with Caseflow")
     fill_in "feedback_feedback", with: "Feedback"
     click_on "Send Feedback"
     expect(page).to have_content("Thanks for your feedback!")
-    page.should have_link("Back to Dispatch", href: "https://www.va.gov")
+    page.should have_link("Back to Caseflow", href: "https://www.va.gov")
   end
 end

--- a/spec/models/feedback_spec.rb
+++ b/spec/models/feedback_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Feedback, type: :model do
-  let(:feedback) { { application: "eFolder Express", username: "alf", feedback: "gr8 app" } }
+  let(:feedback) { { subject: "eFolder Express", username: "alf", feedback: "gr8 app" } }
 
   after do
     Feedback.delete_all


### PR DESCRIPTION
… and tests.
![caseflowfeedback 2](https://cloud.githubusercontent.com/assets/4960030/20810832/52731934-b7d9-11e6-9446-e03db2461c5e.png)
![caseflowfeedback 3](https://cloud.githubusercontent.com/assets/4960030/20810834/57e784ae-b7d9-11e6-8428-09764b6f9421.png)
![caseflowfeedback 4](https://cloud.githubusercontent.com/assets/4960030/20810840/5c9b3de2-b7d9-11e6-9c1b-1f970f1e3f13.png)

To test - make sure 'Caseflow' instead of Certification shows on all Submitting Feedback pages. For admin view - make sure submitted feedback shows as with 'Caseflow' subject you submitted. 
rake db:migrate
rake db:test:prepare (for rspec)

fixes #51 

