### PR TITLE
Add rails stdout logging

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,8 @@ gem "puma", "~> 2.16.0"
 
 gem "httparty"
 
+gem 'rails_stdout_logging'
+
 gem 'pg', platforms: :ruby
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -190,6 +190,7 @@ GEM
       rails-deprecated_sanitizer (>= 1.0.1)
     rails-html-sanitizer (1.0.3)
       loofah (~> 2.0)
+    rails_stdout_logging (0.0.5)
     railties (4.2.7.1)
       actionpack (= 4.2.7.1)
       activesupport (= 4.2.7.1)
@@ -309,6 +310,7 @@ DEPENDENCIES
   pg
   puma (~> 2.16.0)
   rails (= 4.2.7.1)
+  rails_stdout_logging
   rainbow
   rb-readline
   rspec


### PR DESCRIPTION
1. Log to stdout instead of rotating log files. 
2. No roller logic to remove

Testing:
1. Without the gem, it writes to development.log
2. With the gem installed, it doesn't write to development.log

connects #79 