### PR TITLE
Anya/67 log errors sentry

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,11 +34,15 @@ gem "httparty"
 
 gem 'rails_stdout_logging'
 
+# Error reporting to Sentry
+gem "sentry-raven"
+
 gem 'pg', platforms: :ruby
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: :ruby
+  gem 'pry'
 
   gem 'rb-readline'
 
@@ -61,6 +65,7 @@ group :development, :test do
   gem 'capybara'
   gem 'sniffybara', git: 'https://github.com/department-of-veterans-affairs/sniffybara.git'
   gem 'simplecov'
+  gem 'launchy'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,6 +92,8 @@ GEM
     docile (1.1.5)
     erubis (2.7.0)
     execjs (2.7.0)
+    faraday (0.9.2)
+      multipart-post (>= 1.2, < 3)
     ffi (1.9.14)
     formatador (0.2.5)
     globalid (0.3.7)
@@ -125,6 +127,8 @@ GEM
       multi_json (~> 1.0)
       therubyracer (~> 0.12.1)
     json (1.8.3)
+    launchy (2.4.3)
+      addressable (~> 2.3)
     libv8 (3.16.14.15)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -145,6 +149,7 @@ GEM
       railties (>= 3.1)
     multi_json (1.12.1)
     multi_xml (0.5.5)
+    multipart-post (2.0.0)
     neat (1.8.0)
       sass (>= 3.3)
       thor (~> 0.19)
@@ -250,6 +255,8 @@ GEM
       childprocess (~> 0.5)
       rubyzip (~> 1.0)
       websocket (~> 1.0)
+    sentry-raven (1.2.2)
+      faraday (>= 0.7.6, < 0.10.x)
     shellany (0.0.1)
     simplecov (0.12.0)
       docile (~> 1.1.0)
@@ -307,7 +314,9 @@ DEPENDENCIES
   jbuilder (~> 2.0)
   jquery-rails
   jshint
+  launchy
   pg
+  pry
   puma (~> 2.16.0)
   rails (= 4.2.7.1)
   rails_stdout_logging
@@ -319,6 +328,7 @@ DEPENDENCIES
   sass-rails (~> 5.0)
   scss_lint
   sdoc (~> 0.4.0)
+  sentry-raven
   simplecov
   sniffybara!
   spring

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,6 +3,7 @@ class ApplicationController < ActionController::Base
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
   before_action :setup_fakes
+  before_action :set_raven_user
 
   def unauthorized
     render status: 403
@@ -40,4 +41,16 @@ class ApplicationController < ActionController::Base
     "cf-logo-image-default"
   end
   helper_method :logo_class
+
+  def set_raven_user
+    if current_user && ENV["SENTRY_DSN"]
+      # Raven sends error info to Sentry.
+      Raven.user_context(
+        id: current_user.css_id,
+        css_id: current_user.css_id,
+        email: current_user.email,
+        station_id: current_user.station_id
+      )
+    end
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,7 @@
 class User
   include ActiveModel::Model
   # Ephemeral values obtained from CSS on auth. Stored in user's session
-  attr_accessor :roles, :css_id, :station_id, :regional_office
+  attr_accessor :roles, :css_id, :station_id, :regional_office, :email
 
   def username
     css_id
@@ -36,6 +36,7 @@ class User
       new(css_id: user["id"],
           station_id: user["station_id"],
           roles: user["roles"],
+          email: user["email"],
           regional_office: user["regional_office"] || session[:regional_office])
     end
 

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,0 +1,5 @@
+if ENV['SENTRY_DSN']
+  Raven.configure do |config|
+    config.dsn = ENV['SENTRY_DSN']
+  end
+end

--- a/spec/feature/admin_page_spec.rb
+++ b/spec/feature/admin_page_spec.rb
@@ -46,4 +46,11 @@ RSpec.feature "Admin Page " do
     expect(page).to have_content("Caseflow")
     expect(page).to have_content("Feedback Posting Test 2")
   end
+
+  scenario "Set Raven user context without errors" do
+    stub_const("ENV", ENV.to_hash.merge("SENTRY_DSN" => "asdf"))
+    User.authenticate!(roles: ["System Admin"])
+    visit "/admin"
+    expect(page).to have_content("User")
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,8 @@
 require "simplecov"
 SimpleCov.start do
+  add_filter "lib/fakes"
+  add_filter "spec/support"
+  add_filter "config/initializers"
   SimpleCov.minimum_coverage_by_file 90
 end
 


### PR DESCRIPTION
Log application errors to Sentry.

Testing:
1. Application starts successfully
2. Needs to be tested on UAT

Note: `SENTRY_DSN` has to be set in the environment 

connected #67 