### PR TITLE
Menu sign out #32

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -13,3 +13,7 @@
 //= require jquery
 //= require jquery_ujs
 //= require_tree .
+
+$(function() {
+  window.Dropdown.bind();
+});

--- a/app/assets/javascripts/application/dropdown.js
+++ b/app/assets/javascripts/application/dropdown.js
@@ -1,0 +1,22 @@
+window.Dropdown = (function($) {
+  // private
+  function onOpen(e) {
+    e.preventDefault(); // Prevent page jump
+    var dropdownMenuId = $(this).attr('href');
+    $(dropdownMenuId).addClass('active');
+  }
+
+  function onClose(e) {
+    if (!$(e.target).parents('.cf-dropdown').length) {
+      $('.cf-dropdown-menu').removeClass('active');
+    }
+  }
+
+  // public
+  return {
+    bind: function() {
+      $(".cf-dropdown-trigger").on('click', onOpen);
+      $(":not(.cf-dropdown)").on('click', onClose);
+    }
+  };
+})($);

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,6 +9,11 @@ class ApplicationController < ActionController::Base
     render status: 403
   end
 
+  def logout
+    session["user"] = nil
+    redirect_to "/"
+  end
+
   private
 
   def setup_fakes

--- a/app/controllers/feedback_controller.rb
+++ b/app/controllers/feedback_controller.rb
@@ -26,7 +26,6 @@ class FeedbackController < ApplicationController
   private
 
   def verify_access
-    # Passed string is irrelevant here, since can? method always returns true for "System Admin" in user.rb
     verify_authorized_roles("System Admin")
   end
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -34,6 +34,7 @@
               <%= current_user.display_name %>
             </a>
             <ul id="menu" class="cf-dropdown-menu" aria-labelledby="menu-trigger">
+              <a href="<%= url_for controller: 'feedback', action: 'new'%>">Sign out</a>
             </ul>
           </div>
         <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -34,7 +34,7 @@
               <%= current_user.display_name %>
             </a>
             <ul id="menu" class="cf-dropdown-menu" aria-labelledby="menu-trigger">
-              <a href="<%= url_for controller: 'feedback', action: 'new'%>">Sign out</a>
+              <a href="<%= url_for controller: 'application', action: 'logout'%>">Sign out</a>
             </ul>
           </div>
         <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,4 +8,5 @@ Rails.application.routes.draw do
   get "health-check" => "health_checks#show"
   get "admin" => "feedback#admin"
 
+  get 'logout', to: 'application#logout'
 end

--- a/spec/feature/logout_spec.rb
+++ b/spec/feature/logout_spec.rb
@@ -1,0 +1,16 @@
+require "rails_helper"
+
+RSpec.feature "Logout" do
+  before do
+    reset_application!
+  end
+
+  scenario "Logging out redirects to home page" do
+    visit "feedback/new"
+    expect(page).to have_content("Tell us about your experience with Caseflow.")
+    expect(page).to have_content("ANNE MERICA (283)")
+    click_on "ANNE MERICA (283)"
+    click_on "Sign out"
+    expect(page).to have_content("Tell us about your experience with Caseflow.")
+  end
+end

--- a/spec/feature/logout_spec.rb
+++ b/spec/feature/logout_spec.rb
@@ -7,10 +7,9 @@ RSpec.feature "Logout" do
 
   scenario "Logging out redirects to home page" do
     visit "feedback/new"
-    expect(page).to have_content("Tell us about your experience with Caseflow.")
-    expect(page).to have_content("ANNE MERICA (283)")
     click_on "ANNE MERICA (283)"
+    expect(page).to have_content("Sign out")
+    page.should have_selector(:link_or_button, "Sign out")
     click_on "Sign out"
-    expect(page).to have_content("Tell us about your experience with Caseflow.")
   end
 end


### PR DESCRIPTION
![caseflow feedback 14](https://cloud.githubusercontent.com/assets/4960030/21670367/8521ed7e-d2e1-11e6-8821-8cb571f13356.png)

Added Sign Out as menu option using javascript function from Caseflow.  
Added action for logout in app controller and relevant route match. 
Added test for it. 
Sign out should go to root page (New Feedback). 