### PR TITLE
Anya/71 generate GitHub issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@
 # Ignore bundler config.
 /.bundle
 
+/.env
+
 # Ignore the default SQLite database.
 /db/*.sqlite3
 /db/*.sqlite3-journal

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ branches:
       - master
 
 addons:
-  sauce_connect: true
 
 # Install PhantomJS 2.0 from source binary, remove once TravisCI environment has PhantomJS 2.0 installed
 # see https://github.com/travis-ci/travis-ci/issues/3225 for more details

--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,9 @@ gem 'rails_stdout_logging'
 # Error reporting to Sentry
 gem "sentry-raven"
 
+# Github API
+gem "octokit", "~> 4.0"
+
 gem 'pg', platforms: :ruby
 
 # Style
@@ -69,6 +72,7 @@ group :development, :test do
   gem 'sniffybara', git: 'https://github.com/department-of-veterans-affairs/sniffybara.git'
   gem 'simplecov'
   gem 'launchy'
+  gem 'dotenv-rails'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,13 +73,13 @@ GEM
       public_suffix (~> 2.0, >= 2.0.2)
     arel (6.0.3)
     ast (2.3.0)
-    aws-sdk (2.6.46)
-      aws-sdk-resources (= 2.6.46)
-    aws-sdk-core (2.6.46)
+    aws-sdk (2.6.47)
+      aws-sdk-resources (= 2.6.47)
+    aws-sdk-core (2.6.47)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.6.46)
-      aws-sdk-core (= 2.6.46)
+    aws-sdk-resources (2.6.47)
+      aws-sdk-core (= 2.6.47)
     aws-sigv4 (1.0.0)
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
@@ -109,6 +109,10 @@ GEM
     debug_inspector (0.0.2)
     diff-lcs (1.2.5)
     docile (1.1.5)
+    dotenv (2.1.2)
+    dotenv-rails (2.1.2)
+      dotenv (= 2.1.2)
+      railties (>= 3.2, < 5.1)
     erubis (2.7.0)
     execjs (2.7.0)
     faraday (0.9.2)
@@ -179,6 +183,8 @@ GEM
     notiffany (0.1.1)
       nenv (~> 0.1)
       shellany (~> 0.0)
+    octokit (4.6.2)
+      sawyer (~> 0.8.0, >= 0.5.3)
     parser (2.3.1.4)
       ast (~> 2.2)
     pg (0.18.4)
@@ -265,6 +271,9 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
+    sawyer (0.8.1)
+      addressable (>= 2.3.5, < 2.6)
+      faraday (~> 0.8, < 1.0)
     scss_lint (0.50.3)
       rake (>= 0.9, < 12)
       sass (~> 3.4.20)
@@ -326,12 +335,14 @@ DEPENDENCIES
   byebug
   capybara
   caseflow!
+  dotenv-rails
   guard-rspec
   httparty
   jbuilder (~> 2.0)
   jquery-rails
   jshint
   launchy
+  octokit (~> 4.0)
   pg
   pry
   puma (~> 2.16.0)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,5 @@
 module ApplicationHelper
+  def use_fakes?
+    Rails.env.development? || Rails.env.demo? || Rails.env.test?
+  end
 end

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -1,4 +1,6 @@
 class Feedback < ActiveRecord::Base
+  include ApplicationHelper
+
   validates :subject, :username, :feedback, presence: true
   validates :contact_email, length: { maximum: 255 }, format: { with: /\A\S*@\S*\z/ }, allow_blank: true
   enum status: {
@@ -6,4 +8,42 @@ class Feedback < ActiveRecord::Base
     in_progress: 1,
     closed: 2
   }
+
+  after_create :create_github_issue
+
+  APPLICATION_LABELS = {
+    "eFolder Express" => "eFolder",
+    "Caseflow Dispatch" => "Dispatch",
+    "Caseflow" => "Certification",
+    "Caseflow Certification" => "Certification"
+  }.freeze
+
+  def github_labels
+    labels = "Product Support Team, Source - Feedback, Current Sprint"
+    labels += ", " + APPLICATION_LABELS[subject] if APPLICATION_LABELS[subject]
+    labels
+  end
+
+  def render_issue_template
+    GithubIssueRenderer.new(username: username,
+                            email: contact_email,
+                            details: feedback).render
+  end
+
+  def issue_number
+    github_url.present? ? github_url.split("/")[6] : ""
+  end
+
+  private
+
+  def create_github_issue
+    url = github.create_issue(title: feedback[0..100],
+                              body: render_issue_template,
+                              labels: github_labels)
+    update_attributes(github_url: url)
+  end
+
+  def github
+    use_fakes? ? Fakes::GithubService.new : GithubService.new
+  end
 end

--- a/app/services/github_issue_renderer.rb
+++ b/app/services/github_issue_renderer.rb
@@ -1,0 +1,14 @@
+require "erb"
+
+class GithubIssueRenderer
+  def initialize(email:, details:, username:)
+    @username = username
+    @email = email
+    @details = details
+    @template = File.read(Rails.root.join("lib/templates/github_issue.erb"))
+  end
+
+  def render
+    ERB.new(@template).result(binding)
+  end
+end

--- a/app/services/github_service.rb
+++ b/app/services/github_service.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+require "erb"
+
+class GithubService
+  REPO = "department-of-veterans-affairs/appeals-support".freeze
+
+  def create_issue(title:, body:, labels:)
+    issue = Octokit.create_issue(REPO, title, body, labels: labels)
+    issue[:html_url] if issue
+  end
+end

--- a/app/views/feedback/admin.html.erb
+++ b/app/views/feedback/admin.html.erb
@@ -7,6 +7,7 @@
         <th scope="col"><h3>Date</h3></th>
         <th scope="col"><h3>Application</h3></th>
         <th scope="col"><h3>Feedback</h3></th>
+        <th scope="col"><h3>Github Issue</h3></th>
         </tr>
       </thead>
 
@@ -21,10 +22,7 @@
             <td class="align-top"><%= feedback.created_at.strftime("%m/%d/%Y") %></td>
             <td class="align-top"><%= feedback.subject %></td>
             <td class="align-top"><%= feedback.feedback %></td>
-            <td class="align-top">
-              <% unless feedback.admin_note.nil? %>
-                <%= feedback.admin_note %>
-              <% end %>
+            <td class="align-top"><%= link_to feedback.issue_number, feedback.github_url, target: "_blank"%>
             </td>
           </tr>
         <% end %>

--- a/config/initializers/octokit.rb
+++ b/config/initializers/octokit.rb
@@ -1,0 +1,3 @@
+Octokit.configure do |c|
+  c.access_token = ENV['GITHUB_ACCESS_TOKEN']
+end

--- a/db/migrate/20170118211220_add_github_url_to_feedback.rb
+++ b/db/migrate/20170118211220_add_github_url_to_feedback.rb
@@ -1,0 +1,5 @@
+class AddGithubUrlToFeedback < ActiveRecord::Migration
+  def change
+    add_column :feedback, :github_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161201194922) do
+ActiveRecord::Schema.define(version: 20170118211220) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -25,6 +25,7 @@ ActiveRecord::Schema.define(version: 20161201194922) do
     t.text     "admin_note"
     t.integer  "status",        default: 0
     t.text     "contact_email"
+    t.string   "github_url"
   end
 
 end

--- a/lib/fakes/github_service.rb
+++ b/lib/fakes/github_service.rb
@@ -1,0 +1,5 @@
+class Fakes::GithubService
+  def create_issue(_args)
+    "https://github.com/department-of-veterans-affairs/caseflow-feedback/issues/95"
+  end
+end

--- a/lib/templates/github_issue.erb
+++ b/lib/templates/github_issue.erb
@@ -1,0 +1,51 @@
+## NSD Contact Information
+**NSD Ticket #:**
+
+**NSD Contact Name:**
+
+**NSD Email:**
+
+## Reporter Information
+**User Name:** <%= @username %>
+
+**Department:**
+
+**Office Location:**
+
+**Contact Number:**
+
+**Email Address:** <%= @email %>
+
+## Issue Description
+**Type of Bug:**
+- [ ] Performance
+- [ ] Security
+- [ ] Functional
+
+**Severity Level:**
+- [ ]    5 - Data loss, data corruption or system unavailable
+- [ ]    4 - Important functionality is unavailable with no workaround
+- [ ]    3 - Important functionality is unavailable but has a reasonable workaround
+- [ ]    2 - Secondary functionality is unavailable but has a reasonable workaround
+- [ ]    1 - Cosmetic issues or some functionality unavailable but has a simple workaround
+
+**Details:**
+<%= @details %>
+
+## Reproduction Steps
+
+
+## Screenshot
+## Sub-Tasks
+- [ ] Send Reporter Acknowledgement
+- [ ] Assess Issue
+- [ ] Assign to Team
+- [ ] Received Team Acknowledgement
+- [ ] Update Reporter
+- [ ] Resolve Issue
+- [ ] Received Completion Notice
+- [ ] Update Reporter - Issue Complete
+- [ ] Close NSD ticket, if applicable
+- [ ] Confirm/Update Knowledge Base
+
+# Related Issues

--- a/spec/feature/admin_page_spec.rb
+++ b/spec/feature/admin_page_spec.rb
@@ -34,12 +34,14 @@ RSpec.feature "Admin Page " do
     expect(page).to have_content("Tell us about your experience with Caseflow")
     User.authenticate!(roles: ["System Admin"])
     visit "/admin"
+    expect(page).to have_link("95")
     expect(page).to have_content("fk@va.gov")
     expect(page).to have_content(Date.current.strftime("%m/%d/%Y"))
     expect(page).to have_content("Caseflow")
     expect(page).to have_content("Feedback Posting Test")
     expect(page).to have_content("DSUSER (283)")
     expect(page).to have_content("Caseflow")
+    expect(Feedback.find_by(feedback: "Feedback Posting Test").github_url).to_not eq nil
   end
 
   scenario "Set Raven user context without errors" do

--- a/spec/models/feedback_spec.rb
+++ b/spec/models/feedback_spec.rb
@@ -20,4 +20,39 @@ RSpec.describe Feedback, type: :model do
       expect { Feedback.create!(f) }.not_to raise_error
     end
   end
+
+  context "callbacks" do
+    it "should update github url after feedback is created" do
+      expect(Feedback.create(feedback).github_url).to_not eq nil
+    end
+  end
+
+  context "#render_issue_template" do
+    it "should generate template correctly" do
+      feedback[:contact_email] = "test@example.com"
+      result = Feedback.create(feedback).render_issue_template
+      expect(result).to match(/alf/)
+      expect(result).to match(/test@example.com/)
+      expect(result).to match(/gr8 app/)
+    end
+  end
+
+  context "#github_labels" do
+    it "it recognizes the subject" do
+      labels = "Product Support Team, Source - Feedback, Current Sprint, eFolder"
+      expect(Feedback.create(feedback).github_labels).to eq labels
+    end
+
+    it "it does not recognize the subject" do
+      labels = "Product Support Team, Source - Feedback, Current Sprint"
+      feedback = Feedback.create(subject: "other", username: "alf", feedback: "gr8 app")
+      expect(feedback.github_labels).to eq labels
+    end
+  end
+
+  context "#issue_number" do
+    it "returns issue number" do
+      expect(Feedback.create(feedback).issue_number).to eq "95"
+    end
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -29,6 +29,8 @@ require "rspec/rails"
 require "capybara"
 Capybara.default_driver = :sniffybara
 
+ActiveRecord::Migration.maintain_test_schema!
+
 # Convenience methods for stubbing current user
 module StubbableUser
   module ClassMethods

--- a/spec/services/github_issue_renderer_spec.rb
+++ b/spec/services/github_issue_renderer_spec.rb
@@ -1,0 +1,9 @@
+describe GithubIssueRenderer do
+  it "should render the template" do
+    renderer = GithubIssueRenderer.new(username: "FG666", email: "test@example.com", details: "wonderful")
+    result = renderer.render
+    expect(result).to match(/FG666/)
+    expect(result).to match(/test@example.com/)
+    expect(result).to match(/wonderful/)
+  end
+end


### PR DESCRIPTION
Automatically generate a Github issue when feedback is submitted

Note: we need to create a "support" user in Github and use this user's access_token to create issues.

connects #71 