### PR TITLE
Enables prometheus /metrics route.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,8 @@ gem 'uglifier', '>= 1.3.0'
 # Use jquery as the JavaScript library
 gem 'jquery-rails'
 
+gem 'prometheus-client'
+
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 2.0'
 # bundle exec rake doc:rails generates the API under doc/api.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -186,12 +186,15 @@ GEM
       cliver (~> 0.3.1)
       websocket-driver (>= 0.2.0)
     powerpack (0.1.1)
+    prometheus-client (0.6.0)
+      quantile (~> 0.2.0)
     pry (0.10.4)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
     public_suffix (2.0.4)
     puma (2.16.0)
+    quantile (0.2.0)
     rack (1.6.5)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -332,6 +335,7 @@ DEPENDENCIES
   jshint
   launchy
   pg
+  prometheus-client
   pry
   puma (~> 2.16.0)
   rails (= 4.2.7.1)

--- a/app/middleware/metrics_auth.rb
+++ b/app/middleware/metrics_auth.rb
@@ -1,0 +1,13 @@
+# Perform basic auth on the Prometheus /metrics endpoint so that we do not
+# expose sensitive data in the open.
+class MetricsAuth < Rack::Auth::Basic
+  def call(env)
+    request = Rack::Request.new(env)
+    case request.path
+    when "/metrics" # perform auth for /metrics
+      super
+    else # skip auth otherwise
+      @app.call(env)
+    end
+  end
+end

--- a/config.ru
+++ b/config.ru
@@ -1,4 +1,26 @@
 # This file is used by Rack-based servers to start the application.
 
 require ::File.expand_path("../config/environment", __FILE__)
+require "rack"
+require "prometheus/client/rack/collector"
+require "prometheus/client/rack/exporter"
+
+# require basic auth for the /metrics route
+use MetricsAuth, "metrics" do |username, password|
+  # if we mistakenly didn't set a password for this route, disable the route
+  password_missing = ENV["METRICS_PASSWORD"].blank?
+  password_matches = [username, password] == [ENV["METRICS_USERNAME"], ENV["METRICS_PASSWORD"]]
+  password_missing ? false : password_matches
+end
+
+# use gzip for the '/metrics' route, since it can get big.
+use Rack::Deflater,
+    if: -> (env, _status, _headers, _body) { env["PATH_INFO"] == "/metrics" }
+
+# traces all HTTP requests
+use Prometheus::Client::Rack::Collector
+
+# exposes a metrics HTTP endpoint to be scraped by a prometheus server
+use Prometheus::Client::Rack::Exporter
+
 run Rails.application

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -38,4 +38,6 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+  ENV["METRICS_USERNAME"] = "caseflow"
+  ENV["METRICS_PASSWORD"] = "caseflow"
 end


### PR DESCRIPTION
Adds prometheus client gem and /metrics route protected by password.

Testing: visited /metrics, entered passwords in dev config, saw route.