### PR TITLE
Application layout was missing sticky footer markup

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -23,38 +23,42 @@
 
 </head>
 <body>
-  <header>
-    <nav class="cf-nav">
-      <div class="usa-grid-full">
-        <a href="/">
-          <h1 class="cf-logo"><%= content_tag(:span, nil, :class => "cf-logo-image #{logo_class}") %>Caseflow</h1>
-        </a>
-        <h2 id="page-title" class="cf-application-title"><span class="cf-logo-name"><%= logo_name %></span><%= yield :page_title %></h2>
+  <div class="content">
+    <header>
+      <nav class="cf-nav">
+        <div class="usa-grid-full">
+          <a href="/">
+            <h1 class="cf-logo"><%= content_tag(:span, nil, :class => "cf-logo-image #{logo_class}") %>Caseflow</h1>
+          </a>
+          <h2 id="page-title" class="cf-application-title"><span class="cf-logo-name"><%= logo_name %></span><%= yield :page_title %></h2>
 
-        <% unless current_user.nil? %>
-          <div class="cf-dropdown cf-nav-dropdown">
-            <a href="#menu" class="cf-dropdown-trigger" id="menu-trigger">
-              <%= current_user.display_name %>
-            </a>
-            <ul id="menu" class="cf-dropdown-menu" aria-labelledby="menu-trigger">
-              <a href="<%= url_for controller: 'application', action: 'logout'%>">Sign out</a>
-            </ul>
-          </div>
-        <% end %>
+          <% unless current_user.nil? %>
+            <div class="cf-dropdown cf-nav-dropdown">
+              <a href="#menu" class="cf-dropdown-trigger" id="menu-trigger">
+                <%= current_user.display_name %>
+              </a>
+              <ul id="menu" class="cf-dropdown-menu" aria-labelledby="menu-trigger">
+                <a href="<%= url_for controller: 'application', action: 'logout'%>">Sign out</a>
+              </ul>
+            </div>
+          <% end %>
+        </div>
+      </nav>
+    </header>
+
+    <main class="usa-grid">
+      <div class="cf-app">
+        <%= yield %>
       </div>
-    </nav>
-  </header>
+    </main>
 
-  <main class="usa-grid">
-    <div class="cf-app">
-      <%= yield %>
-    </div>
-  </main>
-
+  </div>
   <footer class="cf-txt-c usa-grid cf-app-footer">
-    <div class="cf-push-left">
-      <span>Built</span> with <abbr title="love">&#9825;</abbr> by the
-      <a href="http://www.va.gov/ds/">Digital Service at the <abbr title="Department of Veterans Affairs">VA</abbr></a>.
+    <div>
+      <div class="cf-push-left">
+        <span>Built</span> with <abbr title="love">&#9825;</abbr> by the
+        <a href="http://www.va.gov/ds/">Digital Service at the <abbr title="Department of Veterans Affairs">VA</abbr></a>.
+      </div>
     </div>
   </footer>
 </body>


### PR DESCRIPTION
Connects #115

Basically added `content` div and extra `div` in `footer`, then re-indented.

This may not fixes the actual IE problem but the markup needs to be there.