### PR TITLE
Use "Deploy" Node for Deployment

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,7 @@ def APP_VERSION = 'HEAD'
 /************************ Common Pipeline boilerplate ************************/
 
 def commonPipeline;
-node {
+node('deploy') {
 
   // withCredentials allows us to expose the secrets in Credential Binding
   // Plugin to get the credentials from Jenkins secrets.

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,9 +36,9 @@ node('deploy') {
     // Checkout the deployment repo for the ansible script. This is needed
     // since the deployment scripts are separated from the source code.
     stage ('checkout-deploy-repo') {
-      sh "git clone https://${env.GIT_CREDENTIAL}@github.com/department-of-veterans-affairs/appeals-deployment"
-      sh "git checkout feature/hot-compatibility-round-2"
+      sh "git clone https://${env.GIT_CREDENTIAL}@github.com/department-of-veterans-affairs/appeals-deployment"      
       dir ('./appeals-deployment/ansible') {
+        sh "git checkout feature/hot-compatibility-round-2"
         if (env.APP_ENV == 'prod') {
           APP_VERSION = sh (
             // magical shell script that will find the latest tag for the repository

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,6 +37,7 @@ node('deploy') {
     // since the deployment scripts are separated from the source code.
     stage ('checkout-deploy-repo') {
       sh "git clone https://${env.GIT_CREDENTIAL}@github.com/department-of-veterans-affairs/appeals-deployment"
+      sh "git checkout feature/hot-compatibility-round-2"
       dir ('./appeals-deployment/ansible') {
         if (env.APP_ENV == 'prod') {
           APP_VERSION = sh (

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,7 @@ def APP_VERSION = 'HEAD'
 /************************ Common Pipeline boilerplate ************************/
 
 def commonPipeline;
-node {
+node('deploy') {
 
   // withCredentials allows us to expose the secrets in Credential Binding
   // Plugin to get the credentials from Jenkins secrets.
@@ -38,7 +38,6 @@ node {
     stage ('checkout-deploy-repo') {
       sh "git clone https://${env.GIT_CREDENTIAL}@github.com/department-of-veterans-affairs/appeals-deployment"      
       dir ('./appeals-deployment/ansible') {
-        sh "git checkout feature/hot-compatibility-round-2"
         if (env.APP_ENV == 'prod') {
           APP_VERSION = sh (
             // magical shell script that will find the latest tag for the repository

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,7 @@ def APP_VERSION = 'HEAD'
 /************************ Common Pipeline boilerplate ************************/
 
 def commonPipeline;
-node('deploy') {
+node {
 
   // withCredentials allows us to expose the secrets in Credential Binding
   // Plugin to get the credentials from Jenkins secrets.


### PR DESCRIPTION
This minor change forces the deployment to use the Jenkins "Deploy" node for deployment. This is needed because the "Deploy" node is in the Utility VPC and has Prod VPC connectivity.