### PR TITLE
Nemo/Updated nokogiri version.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -167,7 +167,7 @@ GEM
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
-    mini_portile2 (2.2.0)
+    mini_portile2 (2.3.0)
     minitest (5.10.1)
     momentjs-rails (2.17.1)
       railties (>= 3.1)
@@ -178,8 +178,8 @@ GEM
       sass (~> 3.4)
       thor (~> 0.19)
     nenv (0.3.0)
-    nokogiri (1.8.0)
-      mini_portile2 (~> 2.2.0)
+    nokogiri (1.8.1)
+      mini_portile2 (~> 2.3.0)
     notiffany (0.1.1)
       nenv (~> 0.1)
       shellany (~> 0.0)
@@ -371,4 +371,4 @@ DEPENDENCIES
   will_paginate
 
 BUNDLED WITH
-   1.15.3
+   1.16.0.pre.2


### PR DESCRIPTION
Updated nokogiri version to 1.8.1 due to security vulnerability. 