### PR TITLE
Implement typeahead search functionality for admin dashboard

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,7 +55,7 @@ gem "pg", platforms: :ruby
 gem "uswds-rails", git: "https://github.com/18F/uswds-rails-gem.git"
 
 group :development, :test do
-  gem 'faker'
+  gem "faker"
   # Call "byebug" anywhere in the code to stop execution and get a debugger console
   gem "byebug", platforms: :ruby
   gem "capybara-screenshot"

--- a/Gemfile
+++ b/Gemfile
@@ -55,6 +55,7 @@ gem "pg", platforms: :ruby
 gem "uswds-rails", git: "https://github.com/18F/uswds-rails-gem.git"
 
 group :development, :test do
+  gem 'faker'
   # Call "byebug" anywhere in the code to stop execution and get a debugger console
   gem "byebug", platforms: :ruby
   gem "capybara-screenshot"
@@ -87,7 +88,7 @@ end
 
 group :development do
   # Access an IRB console on exception pages or by using <%= console %> in views
-  gem "web-console", "~> 2.0", platforms: :ruby
+  gem "web-console", "~> 3.0", platforms: :ruby
 
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   # gem "spring", platforms: :ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,8 +80,7 @@ GEM
     aws-sdk-resources (2.11.2)
       aws-sdk-core (= 2.11.2)
     aws-sigv4 (1.0.2)
-    binding_of_caller (0.8.0)
-      debug_inspector (>= 0.0.1)
+    bindex (0.5.0)
     bourbon (4.2.7)
       sass (~> 3.4)
       thor (~> 0.19)
@@ -109,15 +108,16 @@ GEM
     crass (1.0.4)
     d3-rails (4.10.2)
       railties (>= 3.1)
-    debug_inspector (0.0.3)
     diff-lcs (1.3)
     docile (1.1.5)
     dotenv (2.2.1)
     dotenv-rails (2.2.1)
       dotenv (= 2.2.1)
       railties (>= 3.2, < 5.2)
-    erubi (1.7.0)
+    erubi (1.7.1)
     execjs (2.7.0)
+    faker (1.8.7)
+      i18n (>= 0.7)
     faraday (0.12.0.1)
       multipart-post (>= 1.2, < 3)
     ffi (1.9.18)
@@ -211,7 +211,7 @@ GEM
     puma (2.16.0)
     quantile (0.2.0)
     rack (2.0.4)
-    rack-test (0.8.2)
+    rack-test (1.0.0)
       rack (>= 1.0, < 3)
     rails (5.1.5)
       actioncable (= 5.1.5)
@@ -238,7 +238,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rainbow (3.0.0)
-    rake (12.3.0)
+    rake (12.3.1)
     rb-fsevent (0.9.8)
     rb-inotify (0.9.8)
       ffi (>= 0.5.0)
@@ -324,11 +324,11 @@ GEM
     uglifier (3.1.13)
       execjs (>= 0.3.0, < 3)
     unicode-display_width (1.3.0)
-    web-console (2.3.0)
-      activemodel (>= 4.0)
-      binding_of_caller (>= 0.7.2)
-      railties (>= 4.0)
-      sprockets-rails (>= 2.0, < 4.0)
+    web-console (3.6.1)
+      actionview (>= 5.0)
+      activemodel (>= 5.0)
+      bindex (>= 0.4.0)
+      railties (>= 5.0)
     websocket (1.2.4)
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
@@ -349,6 +349,7 @@ DEPENDENCIES
   capybara-screenshot
   caseflow!
   dotenv-rails
+  faker
   guard-rspec
   httparty
   jbuilder (~> 2.0)
@@ -377,7 +378,7 @@ DEPENDENCIES
   tzinfo-data
   uglifier (>= 1.3.0)
   uswds-rails!
-  web-console (~> 2.0)
+  web-console (~> 3.0)
   will_paginate
 
 BUNDLED WITH

--- a/app/assets/javascripts/search.js
+++ b/app/assets/javascripts/search.js
@@ -23,8 +23,10 @@ $(document).ready(function () {
       state.data = $('.data').data('feedback');
       state.table = $('#feedback');
       state.pagination = $('#pagination');
-      processState();
-      render();
+      if (state.data != null && state.data.length !== 0) {
+        processState();
+        render();
+      }
   }
 
   function reevaluate() {

--- a/app/assets/javascripts/search.js
+++ b/app/assets/javascripts/search.js
@@ -12,7 +12,7 @@ $(document).ready(function () {
     $( "#search-field" ).keyup( function() {
       state.term = this.value;
       state.timers.push(setTimeout(function(){
-        reevaluate()}, TYPEAHEAD_DELAY));
+        reevaluate();}, TYPEAHEAD_DELAY));
     });
   }
 
@@ -72,8 +72,8 @@ $(document).ready(function () {
 
   function render() {
     
-    state.feedback.forEach(function (value, i) {
-      var tr = state.table.append('<tr></tr>');;
+    state.feedback.forEach(function (value) {
+      var tr = state.table.append('<tr></tr>');
        tr.append('<td class="user-col">'+value.user+'</td>');
        tr.append('<td class="date-col">'+value.date+'</td>');
        tr.append('<td class="app-col">'+value.app+'</td>');
@@ -84,13 +84,13 @@ $(document).ready(function () {
   }
 
   function validateData() {
-    if (state.data != null && state.data.length != 0) {
-      state.data_valid = true
+    if (state.data != null && state.data.length !== 0) {
+      state.data_valid = true;
     }
   }
 
   function getFormattedDate(date_string) {
-    var date = new Date(date_string)
+    var date = new Date(date_string);
     var year = date.getFullYear().toString().substr(-2);
 
     var month = (1 + date.getMonth()).toString();

--- a/app/assets/javascripts/search.js
+++ b/app/assets/javascripts/search.js
@@ -1,0 +1,107 @@
+// Place all the behaviors and hooks related to the matching controller here.
+// All this logic will automatically be available in application.js.
+$(document).ready(function () {
+
+  var state = {};
+  var TYPEAHEAD_DELAY = 2000;
+  var SEARCH_URL = '/search';
+
+  function init() {
+    initState();
+
+    $( "#search-field" ).keyup( function() {
+      state.term = this.value;
+      state.timers.push(setTimeout(function(){
+        reevaluate()}, TYPEAHEAD_DELAY));
+    });
+  }
+
+  function initState() {
+      state.feedback = [];
+      state.timers = [];
+      state.data_valid = false;
+      state.data = $('.data').data('feedback');
+      state.table = $('#feedback');
+      processState();
+      render();
+  }
+
+  function reevaluate() {
+    
+    resetState();
+    fetchState();
+  }
+
+  function resetState() {
+    state.data = {};
+    state.table.empty();
+    state.data_valid = false;
+    state.feedback = [];
+    state.timers.forEach(function (value) {
+      clearTimeout(value);
+    });
+  }
+
+  function fetchState() {
+     $.get( SEARCH_URL, {search: state.term}, function( data ) {
+      state.data = data;
+        validateData();
+        if (state.data_valid) {
+          processState();
+          render();
+        }
+    });
+  }
+
+  function processState() {
+
+    state.data.forEach(function (value, i) {
+      state.feedback[i] = {};
+      state.feedback[i].user = typeof value.contact_email === "undefined" ? value.username :  value.contact_email;
+      state.feedback[i].date = getFormattedDate(value.created_at);
+      state.feedback[i].app = value.subject;
+      state.feedback[i].feedback = value.feedback;
+      state.feedback[i].github_url = value.github_url;
+      state.feedback[i].issue = getIssueNumber(value.github_url);
+      state.feedback[i].pii = value.veteran_pii;
+    });
+  }
+
+  function render() {
+    
+    state.feedback.forEach(function (value, i) {
+      var tr = state.table.append('<tr></tr>');;
+       tr.append('<td class="user-col">'+value.user+'</td>');
+       tr.append('<td class="date-col">'+value.date+'</td>');
+       tr.append('<td class="app-col">'+value.app+'</td>');
+       tr.append('<td class="feedback-col">'+value.feedback+'</td>');
+       tr.append('<td class="issue-col"><a target="_blank" href='+value.github_url+'>'+value.issue+'</a></td>');
+       tr.append('<td class="pii-col">'+value.pii+'</td>');
+    }); 
+  }
+
+  function validateData() {
+    if (state.data != null && state.data.length != 0) {
+      state.data_valid = true
+    }
+  }
+
+  function getFormattedDate(date_string) {
+    var date = new Date(date_string)
+    var year = date.getFullYear().toString().substr(-2);
+
+    var month = (1 + date.getMonth()).toString();
+    month = month.length > 1 ? month : '0' + month;
+
+    var day = date.getDate().toString();
+    day = day.length > 1 ? day : '0' + day;
+    
+    return month + '/' + day + '/' + year;
+  }
+
+  function getIssueNumber(url) {
+    return /[^/]*$/.exec(url)[0];
+  }
+
+  init();
+});

--- a/app/assets/javascripts/search.js
+++ b/app/assets/javascripts/search.js
@@ -90,15 +90,12 @@ $(document).ready(function () {
   }
 
   function getFormattedDate(date_string) {
-    var date = new Date(date_string);
-    var year = date.getFullYear().toString().substr(-2);
+    date_string = new Date(date_string).toISOString();
+    var date = date_string.substring(0,10);
+    var month = date.substring(5,7);
+    var day = date.substring(8,10);
+    var year = date.substring(2,4);
 
-    var month = (1 + date.getMonth()).toString();
-    month = month.length > 1 ? month : '0' + month;
-
-    var day = date.getDate().toString();
-    day = day.length > 1 ? day : '0' + day;
-    
     return month + '/' + day + '/' + year;
   }
 

--- a/app/assets/javascripts/search.js
+++ b/app/assets/javascripts/search.js
@@ -22,6 +22,7 @@ $(document).ready(function () {
       state.data_valid = false;
       state.data = $('.data').data('feedback');
       state.table = $('#feedback');
+      state.pagination = $('#pagination');
       processState();
       render();
   }
@@ -35,6 +36,7 @@ $(document).ready(function () {
   function resetState() {
     state.data = {};
     state.table.empty();
+    state.pagination.empty();
     state.data_valid = false;
     state.feedback = [];
     state.timers.forEach(function (value) {
@@ -65,6 +67,7 @@ $(document).ready(function () {
       state.feedback[i].issue = getIssueNumber(value.github_url);
       state.feedback[i].pii = value.veteran_pii;
     });
+
   }
 
   function render() {

--- a/app/assets/stylesheets/_main.scss
+++ b/app/assets/stylesheets/_main.scss
@@ -80,6 +80,7 @@ label {
 
 .user-col {
   width: 200px;
+  word-wrap: break-word;
   vertical-align: top;
   padding-bottom: 30px;
 }

--- a/app/controllers/feedback_controller.rb
+++ b/app/controllers/feedback_controller.rb
@@ -30,28 +30,21 @@ class FeedbackController < ApplicationController
   end
 
   def search
-    begin 
-      term = params[:search].tr('*','%')
-      term<<'%' unless term.end_with?('%')
-      date_term = transform_date(term.dup) 
-      github_term = term.dup.prepend('%')
-      if !params[:search].blank?
-        @feedback = Feedback.where('contact_email ILIKE ?', term)
-        .or(Feedback.where('subject ILIKE ?', term))
-        .or(Feedback.where('created_at::text ILIKE ?', date_term))
-        .or(Feedback.where('github_url ILIKE ?', github_term))
-        .or(Feedback.where('veteran_pii ILIKE ?', term)).paginate(page: params[:page], per_page: 5)
-      else
-        admin
-      end
-    rescue StandardError => e
-      Rails.logger.error "FeedbackController failed search: #{e.message}"
-      @feedback = Feedback.none.paginate(:page => params[:page]) 
+    term = get_search_term(params[:search])
+    date_term = get_date_term(term.dup)
+    github_term = get_github_term(term.dup)
+    if !params[:search].blank?
+      search_feedback(term, date_term, github_term)
+    else
+      admin
     end
     respond_to do |format|
       format.json { render json: @feedback }
-      format.html { render :admin } 
+      format.html { render :admin }
     end
+  rescue StandardError => e
+    Rails.logger.error "FeedbackController failed search: #{e.message}"
+    @feedback = Feedback.none.paginate(page: params[:page])
   end
 
   private
@@ -62,18 +55,36 @@ class FeedbackController < ApplicationController
       .merge(subject: session[:subject], username: current_user.display_name)
   end
 
-  def transform_date(date)
-    if date.include?('/')
+  def search_feedback(term, date_term, github_term)
+    @feedback = Feedback.where("contact_email ILIKE ?", term)
+      .or(Feedback.where("subject ILIKE ?", term))
+      .or(Feedback.where("created_at::text ILIKE ?", date_term))
+      .or(Feedback.where("github_url ILIKE ?", github_term))
+      .or(Feedback.where("veteran_pii ILIKE ?", term)).paginate(page: params[:page], per_page: 5)
+  end
+
+  def get_search_term(search)
+    term = search.tr("*", "%")
+    term << "%" unless term.end_with?("%")
+  end
+
+  def get_date_term(date)
+    if date.include?("/")
       array = date.split(/\//)
       # Dashboard shows mm/dd/yy, but postgres saves as yyyy-mm-dd in created_at column
-      if array.size == 3 
-        array[2]<<'_' if array[2].length == 1 
-        array.rotate!(-1)  
+      if array.size == 3
+        array[2] << "_" if array[2].length == 1
+        array.rotate!(-1)
       end
-      date = array.join('-')
+      date = array.join("-")
     end
-    date.prepend('%') unless date.start_with?('%')
-    date<<'%' unless date.end_with?('%')
-    date<<'__:__:__.%'
+    date.prepend("%") unless date.start_with?("%")
+    date << "%" unless date.end_with?("%")
+    # created_at time stamp pattern at the end
+    date << "__:__:__.%"
+  end
+
+  def get_github_term(search)
+    search.prepend("%")
   end
 end

--- a/app/controllers/feedback_controller.rb
+++ b/app/controllers/feedback_controller.rb
@@ -30,21 +30,23 @@ class FeedbackController < ApplicationController
   end
 
   def search
-    term = get_search_term(params[:search])
-    date_term = get_date_term(term.dup)
-    github_term = get_github_term(term.dup)
-    if !params[:search].blank?
-      search_feedback(term, date_term, github_term)
-    else
-      admin
+    begin
+      term = get_search_term(params[:search])
+      date_term = get_date_term(term.dup)
+      github_term = get_github_term(term.dup)
+      if !params[:search].blank?
+        search_feedback(term, date_term, github_term)
+      else
+        admin
+      end
+    rescue StandardError => e
+      Rails.logger.error "FeedbackController failed search: #{e.message}"
+      @feedback = Feedback.none.paginate(page: params[:page])
     end
     respond_to do |format|
       format.json { render json: @feedback }
       format.html { render :admin }
     end
-  rescue StandardError => e
-    Rails.logger.error "FeedbackController failed search: #{e.message}"
-    @feedback = Feedback.none.paginate(page: params[:page])
   end
 
   private
@@ -66,6 +68,7 @@ class FeedbackController < ApplicationController
   def get_search_term(search)
     term = search.tr("*", "%")
     term << "%" unless term.end_with?("%")
+    term
   end
 
   def get_date_term(date)

--- a/app/controllers/feedback_controller.rb
+++ b/app/controllers/feedback_controller.rb
@@ -2,7 +2,7 @@
 
 class FeedbackController < ApplicationController
   before_action :verify_authentication
-  before_action :verify_system_admin, except: [:new, :create, :count]
+  before_action :verify_system_admin, except: [:new, :create]
 
   def admin
     @feedback = Feedback.paginate(page: params[:page], per_page: 5).order("created_at DESC")
@@ -29,11 +29,51 @@ class FeedbackController < ApplicationController
     end
   end
 
+  def search
+    begin 
+      term = params[:search].tr('*','%')
+      term<<'%' unless term.end_with?('%')
+      date_term = transform_date(term.dup) 
+      github_term = term.dup.prepend('%')
+      if !params[:search].blank?
+        @feedback = Feedback.where('contact_email ILIKE ?', term)
+        .or(Feedback.where('subject ILIKE ?', term))
+        .or(Feedback.where('created_at::text ILIKE ?', date_term))
+        .or(Feedback.where('github_url ILIKE ?', github_term))
+        .or(Feedback.where('veteran_pii ILIKE ?', term)).paginate(page: params[:page], per_page: 5)
+      else
+        admin
+      end
+    rescue StandardError => e
+      Rails.logger.error "FeedbackController failed search: #{e.message}"
+      @feedback = Feedback.none.paginate(:page => params[:page]) 
+    end
+    respond_to do |format|
+      format.json { render json: @feedback }
+      format.html { render :admin } 
+    end
+  end
+
   private
 
   def feedback_params
     params.require(:feedback)
       .permit(:feedback, :contact_email, :veteran_pii)
       .merge(subject: session[:subject], username: current_user.display_name)
+  end
+
+  def transform_date(date)
+    if date.include?('/')
+      array = date.split(/\//)
+      # Dashboard shows mm/dd/yy, but postgres saves as yyyy-mm-dd in created_at column
+      if array.size == 3 
+        array[2]<<'_' if array[2].length == 1 
+        array.rotate!(-1)  
+      end
+      date = array.join('-')
+    end
+    date.prepend('%') unless date.start_with?('%')
+    date<<'%' unless date.end_with?('%')
+    date<<'__:__:__.%'
   end
 end

--- a/app/views/feedback/admin.html.erb
+++ b/app/views/feedback/admin.html.erb
@@ -12,7 +12,7 @@
 		        <%= form_tag search_path, method: :get, class: "usa-search usa-search-small"  do %>
 				  <%= label_tag "search-field", nil, class: "usa-sr-only" %>
 				  <%= search_field_tag "search", nil, id: "search-field", class: 'form-control typeahead' %>
-				  <%= button_tag ''	%>
+				  <%= button_tag '', title: "search"%>
 				<% end %>
 		      </div>
     		</div>

--- a/app/views/feedback/admin.html.erb
+++ b/app/views/feedback/admin.html.erb
@@ -11,7 +11,7 @@
 		      <div role="search">
 		        <%= form_tag search_path, method: :get, class: "usa-search usa-search-small"  do %>
 				  <%= label_tag "search-field", nil, class: "usa-sr-only" %>
-				  <%= search_field_tag "search", nil, id: "search-field", class: 'form-control typeahead' %>
+				  <%= search_field_tag "search", params[:search], id: "search-field", class: 'form-control typeahead' %>
 				  <%= button_tag '', title: "search"%>
 				<% end %>
 		      </div>

--- a/app/views/feedback/admin.html.erb
+++ b/app/views/feedback/admin.html.erb
@@ -34,5 +34,5 @@
 	<tbody id="feedback">
 	</tbody>
     </table>
-    <ul><%= will_paginate @feedback =%></ul>
+    <ul id="pagination"><%= will_paginate @feedback =%></ul>
 </div>

--- a/app/views/feedback/admin.html.erb
+++ b/app/views/feedback/admin.html.erb
@@ -1,9 +1,23 @@
+<%= content_tag :div, class: "data", data: {feedback: @feedback} do %>
+<% end %>
 <div class="cf-app-msg-screen cf-app-segment cf-app-segment--alt">
 	<div class="cf-push-left">
-    <h2>Current Feedback</h2>
-  <div class="feedback-paragraph"><span >New feedback submissions today:  </span><span class ="count"><%= @count %></span>
-  </div>
-  </div>
+    	<h2>Current Feedback</h2>
+  		<div class="feedback-paragraph"><span >New feedback submissions today:  </span><span class ="count"><%= @count %></span></div>
+  	</div>
+  	 <div class="cf-push-right">
+	  	<div class="usa-grid">
+		    <div class="usa-width-one-whole">
+		      <div role="search">
+		        <%= form_tag search_path, method: :get, class: "usa-search usa-search-small"  do %>
+				  <%= label_tag "search-field", nil, class: "usa-sr-only" %>
+				  <%= search_field_tag "search", nil, id: "search-field", class: 'form-control typeahead' %>
+				  <%= button_tag ''	%>
+				<% end %>
+		      </div>
+    		</div>
+	  	</div>
+	 </div>
     <table class="usa-table-borderless table-width" summary="Each row represents a feedback">
 	<caption hidden>This table shows all feedback submitted.</caption>
 	<thead>
@@ -17,22 +31,7 @@
 	    </tr>
 	</thead>
 
-	<tbody>
-	    <% @feedback.each do |feedback| %>
-		<tr>
-		    <% if feedback.contact_email.blank? %>
-			<td class="user-col"><%= feedback.username %></td>
-		    <% else %>
-			<td class="user-col"><%= feedback.contact_email %></td>
-		    <% end %>
-		    <td class="date-col"><%= feedback.created_at.strftime("%m/%d/%Y") %></td>
-		    <td class="app-col"><%= feedback.subject %></td>
-		    <td class="feedback-col"><%= feedback.feedback %></td>
-		    <td class="issue-col"><%= link_to feedback.issue_number, feedback.github_url, target: "_blank"%>
-		    <td class="pii-col"><%= feedback.veteran_pii %></td>
-		    </td>
-		</tr>
-	    <% end %>
+	<tbody id="feedback">
 	</tbody>
     </table>
     <ul><%= will_paginate @feedback =%></ul>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,4 +8,5 @@ Rails.application.routes.draw do
   get "health-check" => "health_checks#show"
   get "admin" => "feedback#admin"
   get 'logout', to: 'application#logout'
+  get 'search' => "feedback#search"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -16,3 +16,4 @@ puts "Admin records after seeding:  #{new_size}"
 puts
 puts "****************************************************************************************************************************"
 puts "****************************************************************************************************************************"
+# 300.times { |n| Feedback.create(username: Faker::Name.name, contact_email: Faker::Internet.email, subject: Faker::Name.name, feedback: Faker::VForVendetta.speech, github_url: "https://github.com/department-of-veterans-affairs/caseflow-feedback/issues/#{n}", veteran_pii: Faker::Number.number(9)) }

--- a/spec/feature/admin_page_spec.rb
+++ b/spec/feature/admin_page_spec.rb
@@ -39,7 +39,7 @@ RSpec.feature "Admin Page " do
     visit "/admin"
     expect(page).to have_link("95")
     expect(page).to have_content("fk@va.gov")
-    expect(page).to have_content(Date.current.strftime("%m/%d/%Y"))
+    expect(page).to have_content(Date.current.strftime("%m/%d/%y"))
     expect(page).to have_content("Caseflow")
     expect(page).to have_content("Admin Page Spec")
     expect(page).to have_content("DSUSER (283)")

--- a/spec/feature/search_feedback_spec.rb
+++ b/spec/feature/search_feedback_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "pry"
+
+RSpec.feature "Search feedback" do
+  before do
+    reset_application!
+    5.times do |n|
+      Feedback.create(username: "#{Faker::Name.name}#{n}",
+                      contact_email: "email#{n}@va.gov",
+                      subject: "Subject#{n}",
+                      feedback: Faker::Name.name,
+                      veteran_pii: "#{n}#{n}#{Faker::Number.number(7)}")
+    end
+  end
+
+  scenario "Load Admin Dashboard page" do
+    User.authenticate!(roles: ["System Admin"])
+    visit "/admin"
+    fill_in "search", with: " "
+    click_on "search"
+    expect(page).to have_css("tbody#feedback tr", count: 5)
+    fill_in "search", with: "email1"
+    click_on "search"
+    expect(page).to have_css("tbody#feedback tr", count: 1)
+    fill_in "search", with: "Subject4"
+    click_on "search"
+    expect(page).to have_css("tbody#feedback tr", count: 1)
+    fill_in "search", with: "11"
+    click_on "search"
+    expect(page).to have_css("tbody#feedback tr", count: 1)
+    fill_in "search", with: Time.zone.today.strftime("%m/%d")
+    click_on "search"
+    expect(page).to have_css("tbody#feedback tr", count: 5)
+    fill_in "search", with: "*1*va.gov"
+    click_on "search"
+    expect(page).to have_css("tbody#feedback tr", count: 1)
+  end
+end


### PR DESCRIPTION
Connects to #69 

To test:
As admin user go to /admin.
Type in different search terms including '*' wild card and make sure results get filtered. There should be a 2 sec delay after typing
Make sure search does filtering by username/email, date, app, issue number and pii 
Make sure pressing Enter gives filtered results
Make sure clicking Search gives filtered results

![search](https://user-images.githubusercontent.com/4960030/39262234-db2213e4-488c-11e8-8892-76e3b078f471.gif)

