### PR TITLE
Update bundler version on Travis 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,8 @@ before_install:
   - tar -xvf $PWD/travis-phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2 -C $PWD/travis-phantomjs
   - export PATH=$PWD/travis-phantomjs/phantomjs-2.1.1-linux-x86_64/bin:$PATH
   - phantomjs -v
-  - echo $(bundle -v)
+  - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
+  - gem install bundler -v '< 2'
 
 before_script:
   - sudo apt-get install pdftk

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ before_install:
   - tar -xvf $PWD/travis-phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2 -C $PWD/travis-phantomjs
   - export PATH=$PWD/travis-phantomjs/phantomjs-2.1.1-linux-x86_64/bin:$PATH
   - phantomjs -v
+  - bundle -v
 
 before_script:
   - sudo apt-get install pdftk

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_install:
   - tar -xvf $PWD/travis-phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2 -C $PWD/travis-phantomjs
   - export PATH=$PWD/travis-phantomjs/phantomjs-2.1.1-linux-x86_64/bin:$PATH
   - phantomjs -v
-  - bundle -v
+  - echo $(bundle -v)
 
 before_script:
   - sudo apt-get install pdftk

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -384,4 +384,4 @@ DEPENDENCIES
   will_paginate
 
 BUNDLED WITH
-   2.0.1
+   1.17.3


### PR DESCRIPTION
```gem install bundler``` installs the latest version of Bundler (which is Bundler 2.0 since Jan 3 2019) 
This breaks Jenkins deployment with the current setup. This PR reverts Bundler version to the old one until we update the one used in deployment. 
More info: 
https://docs.travis-ci.com/user/languages/ruby/